### PR TITLE
Support for https, <amp-anim> and <amp-iframe>

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -9,12 +9,18 @@ var merge = require('lodash.merge')
   , async = require('async')
   , url = require('url')
   , http = require('http')
+  , https = require('https')
   , sizeOf = require('image-size')
   , helpers = require('./helpers');
 
 var DEFAULTS = {
   img: {
     layout: 'responsive'
+  },
+  iframe: {
+    layout: 'responsive',
+    width: 600,
+    height: 400
   }
 };
 
@@ -112,28 +118,45 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       });
     }
 
-    if (element.name === 'img' && amperize.config.img) {
-      element.name = 'amp-img';
+    function getImageSize(element) {
+      var options = url.parse(element.attribs.src);
+      var request = element.attribs.src.indexOf('https') === 0 ? https : http;
 
-      if (!element.attribs.layout) {
-        element.attribs.layout = amperize.config.img.layout;
-      }
+      options.headers = { 'User-Agent': 'Mozilla/5.0' };
 
-      if ((!element.attribs.width || !element.attribs.height) && element.attribs.src.indexOf('http') === 0) {
-        var options = url.parse(element.attribs.src);
+      return request.get(options, function (response) {
+        var chunks = [];
 
-        return http.get(options, function (response) {
-          var chunks = [];
-
-          response.on('data', function (chunk) {
-            chunks.push(chunk);
-          }).on('end', function () {
-            var dimensions = sizeOf(Buffer.concat(chunks));
-            element.attribs.width = dimensions.width;
-            element.attribs.height = dimensions.height;
-            return enter();
-          });
+        response.on('data', function (chunk) {
+          chunks.push(chunk);
+        }).on('end', function () {
+          var dimensions = sizeOf(Buffer.concat(chunks));
+          element.attribs.width = dimensions.width;
+          element.attribs.height = dimensions.height;
+          return enter();
         });
+      });
+    }
+
+    if (element.name === 'img' && amperize.config.img) {
+      // when we have a gif it should be <amp-anim>.
+      element.name = element.attribs.src.match(/(\.gif$)/) ? 'amp-anim' : 'amp-img';
+
+      if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
+        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
+        if (element.attribs.src.indexOf('http') === 0) {
+            return getImageSize(element);
+        }
+      }
+    }
+
+    if (element.name ==='iframe') {
+      element.name = 'amp-iframe';
+
+      if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
+        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
+        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
+        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
       }
     }
 

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -27,9 +27,14 @@ describe('Amperize', function () {
     it('which has default options', function () {
       expect(amperize).to.have.property('config');
       expect(amperize.config).to.be.eql({
-        img: {
-          layout: 'responsive'
-        }
+          img: {
+            layout: 'responsive'
+          },
+          iframe: {
+            layout: 'responsive',
+            width: 600,
+            height: 400
+          }
       });
     });
 
@@ -56,6 +61,7 @@ describe('Amperize', function () {
   });
 
   describe('#parse', function () {
+    this.timeout(15000);
     it('throws an error if no callback provided', function () {
       function err() {
         amperize.parse('', null);
@@ -64,12 +70,54 @@ describe('Amperize', function () {
       expect(err).throws('No callback provided');
     });
 
-    it('transforms <img> into <amp-img></amp-img>', function (done) {
-      amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256">', function (error, result) {
-        expect(result).to.be.equal('<amp-img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256" layout="responsive" width="256" height="256"></amp-img>');
+    it('transforms <img> with layout property into <amp-img></amp-img> without overriding it and full image dimensions', function (done) {
+      amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256" layout="FIXED">', function (error, result) {
+        expect(result).to.contain('<amp-img');
+        expect(result).to.contain('src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256"');
+        expect(result).to.contain('layout="FIXED"');
+        expect(result).to.contain('width="256"');
+        expect(result).to.contain('height="256"');
+        expect(result).to.contain('</amp-img>');
         done();
       });
     });
+
+    it('transforms .gif <img> with only height property into <amp-anim></amp-anim> with full dimensions by overriding them', function (done) {
+      amperize.parse('<img src="https://media.giphy.com/media/l46CtzgjhTm29Cbjq/giphy.gif" height="500">', function (error, result) {
+        expect(result).to.contain('<amp-anim');
+        expect(result).to.contain('src="https://media.giphy.com/media/l46CtzgjhTm29Cbjq/giphy.gif"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="800"');
+        expect(result).to.contain('height="600"');
+        expect(result).to.contain('</amp-anim>');
+        done();
+      });
+    });
+
+    it('transforms <iframe> with only width property into <amp-iframe></amp-iframe> with full dimensions withour overriding them', function (done) {
+      amperize.parse('<iframe src="https://www.youtube.com/embed/HMQkV5cTuoY" width="400"></iframe>', function (error, result) {
+        expect(result).to.contain('<amp-iframe');
+        expect(result).to.contain('src="https://www.youtube.com/embed/HMQkV5cTuoY"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="400"');
+        expect(result).to.contain('height="400"');
+        expect(result).to.contain('</amp-iframe>');
+        done();
+      });
+    });
+
+    it('transforms local <img> into <amp-img></amp-img> without image dimensions', function (done) {
+      amperize.parse('<img src="/content/images/IMG_xyz.jpg">', function (error, result) {
+        expect(result).to.contain('<amp-img');
+        expect(result).to.contain('src="/content/images/IMG_xyz.jpg"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.not.contain('width');
+        expect(result).to.not.contain('height');
+        expect(result).to.contain('</amp-img>');
+        done();
+      });
+    });
+
   });
 
   describe('#amperizer', function () {


### PR DESCRIPTION
no issue

I made some more changes. Hope you like it! ;)

- new function `getImageSize()` to make code reusable
- checks if the url should be requested with `HTTP` or `HTTPS`
- adds transform to `<amp-anim>` if image in `<img>` tag is a `GIF`
- when an image is given either width or height property, we check it again and override it
- adds transform from `<iframe>` to `<amp-iframe>` including default width and height
- when an `<iframe>` is given either width or height property, we take the default value for the missing one
- updates test and sets mocha timeout to 15000ms, as we do multiple requests