### PR TITLE
Improve error handling and test

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -15,12 +15,15 @@ var merge = require('lodash.merge')
 
 var DEFAULTS = {
   img: {
-    layout: 'responsive'
+    layout: 'responsive',
+    width: 600,
+    height: 400,
   },
   iframe: {
     layout: 'responsive',
     width: 600,
-    height: 400
+    height: 400,
+    sandbox: 'allow-scripts allow-same-origin'
   }
 };
 
@@ -118,23 +121,43 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       });
     }
 
+    /**
+     * Get the image sizes (width and heigth plus type of image)
+     *
+     * https://github.com/image-size/image-size
+     *
+     * @param {Object} element
+     * @return {Object} element incl. width and height
+     */
     function getImageSize(element) {
       var options = url.parse(element.attribs.src);
       var request = element.attribs.src.indexOf('https') === 0 ? https : http;
 
+      // We need the user-agent, otherwise some https request may fail (e. g. cloudfare)
       options.headers = { 'User-Agent': 'Mozilla/5.0' };
 
       return request.get(options, function (response) {
         var chunks = [];
-
         response.on('data', function (chunk) {
           chunks.push(chunk);
         }).on('end', function () {
-          var dimensions = sizeOf(Buffer.concat(chunks));
-          element.attribs.width = dimensions.width;
-          element.attribs.height = dimensions.height;
-          return enter();
+            try {
+                var dimensions = sizeOf(Buffer.concat(chunks));
+                element.attribs.width = dimensions.width;
+                element.attribs.height = dimensions.height;
+                return enter();
+            } catch (err) {
+                // fallback to default values, so the HTML get validated at least
+                element.attribs.width = amperize.config.img.width;
+                element.attribs.height = amperize.config.img.height;
+                return enter();
+            }
         });
+      }).on('error', function () {
+        // fallback to default values, so the HTML get validated at least
+        element.attribs.width = amperize.config.img.width;
+        element.attribs.height = amperize.config.img.height;
+        return enter();
       });
     }
 
@@ -146,6 +169,9 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
         element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
         if (element.attribs.src.indexOf('http') === 0) {
             return getImageSize(element);
+        } else {
+            element.attribs.width = amperize.config.img.width;
+            element.attribs.height = amperize.config.img.height;
         }
       }
     }
@@ -154,9 +180,24 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       element.name = 'amp-iframe';
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
+        // <amp-iframe> must be with 'https' protocol otherwise it will not get validated by AMP.
+        // If we're unable to replace it, we will deal with the valitation error, but at least
+        // we tried.
+        if (element.attribs.src.indexOf('https://') === -1) {
+            if (element.attribs.src.indexOf('http://') === 0) {
+                // Replace 'http' with 'https', so the validation passes
+                element.attribs.src = element.attribs.src.replace(/^http:\/\//i, 'https://');
+            } else if (element.attribs.src.indexOf('//') === 0) {
+                // Giphy embedded iFrames are without protocol and start with '//', so at least
+                // we can fix those cases.
+                element.attribs.src = 'https:' + element.attribs.src;
+            }
+        }
+
         element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
         element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
         element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
+        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "htmlparser2": "3.9.1",
     "image-size": "0.5.0",
     "lodash.merge": "4.4.0",
-    "node-uuid": "1.4.7"
+    "nock": "^8.0.0",
+    "node-uuid": "1.4.7",
+    "rewire": "^2.5.2"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
no issue

While working with Amperizer in a real project, I found some more issues:
- `<amp-iframe>` urls MUST start with `https`, so I replace `http` with `https` or add it, when the urls starts with `//` like Giphy does for example
- Most of the `<amp-iframe>` elements need the additional `sandbox: 'allow-scripts allow-same-origin'` attribute, otherwise the validation fails very often.
- Catching the errors now, `image-size` might throw
- Fallbacks for any case, the image sizes couldn't be fetched. I added default values to the config (`width: 600` & `height: 400`), so at least the AMP validation passes.
- Testimprovements:
	- instead of making real request with every test (now we have to do some more requests), I added 'nock' as dependency to mock the http/https requests. This enables us as well to return errors and have a better handling for them.
	- added 'rewire' as dependency to stub the `image-size` module. This has it's own tests and we just want it to return values or throw errors if needed in test.