### PR TITLE
[HOTFIX] 🐛  Return error if no `src` attribute provided

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -161,6 +161,10 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       });
     }
 
+    if ((element.name === 'img' || element.name === 'iframe') && !element.attribs.src) {
+      return enter('no src for ' + element.name + ' tag');
+    }
+
     if (element.name === 'img' && amperize.config.img) {
       // when we have a gif it should be <amp-anim>.
       element.name = element.attribs.src.match(/(\.gif$)/) ? 'amp-anim' : 'amp-img';

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -187,6 +187,20 @@ describe('Amperize', function () {
       });
     });
 
+    it('can handle <img> tag without src', function (done) {
+      amperize.parse('<img>', function (error, result) {
+        expect(result).to.not.exist;
+        done();
+      });
+    });
+
+    it('can handle <iframe> tag without src', function (done) {
+      amperize.parse('<iframe>', function (error, result) {
+        expect(result).to.not.exist;
+        done();
+      });
+    });
+
     it('can handle request errors by falling back to the default values defined in config', function (done) {
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')


### PR DESCRIPTION
no issue

Add error handling, if an `<img>` or `<iframe>` tag is submitted without having the
necessary `src` attribute.