### PR TITLE
✨ Add support for <audio>

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -108,6 +108,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
 
     function enter(error) {
       if (error) {
+        console.log('error', error);
         return done(error);
       }
 
@@ -159,6 +160,10 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
         element.attribs.height = amperize.config.img.height;
         return enter();
       });
+    }
+
+    if ((element.name === 'img' || element.name === 'iframe') && !element.attribs.src) {
+      return enter('no src for ' + element.name + ' tag');
     }
 
     if (element.name === 'img' && amperize.config.img) {

--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -108,7 +108,6 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
 
     function enter(error) {
       if (error) {
-        console.log('error', error);
         return done(error);
       }
 
@@ -185,7 +184,20 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       element.name = 'amp-iframe';
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
-        // <amp-iframe> must be with 'https' protocol otherwise it will not get validated by AMP.
+
+        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
+        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
+        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
+        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
+      }
+    }
+
+    if (element.name === 'audio') {
+        element.name = 'amp-audio';
+    }
+
+    if (element.attribs && element.attribs.src) {
+        // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
         // If we're unable to replace it, we will deal with the valitation error, but at least
         // we tried.
         if (element.attribs.src.indexOf('https://') === -1) {
@@ -198,13 +210,8 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
                 element.attribs.src = 'https:' + element.attribs.src;
             }
         }
-
-        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
-        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
-        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
-        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
-      }
     }
+
 
     return enter();
   }, done);

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -187,6 +187,20 @@ describe('Amperize', function () {
       });
     });
 
+    it('can handle <img> tag without src', function (done) {
+      amperize.parse('<img>', function (error, result) {
+        expect(result).to.not.exist;
+        done();
+      });
+    });
+
+    it('can handle <iframe> tag without src', function (done) {
+      amperize.parse('<iframe>', function (error, result) {
+        expect(result).to.not.exist;
+        done();
+      });
+    });
+
     it('can handle request errors by falling back to the default values defined in config', function (done) {
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -201,6 +201,39 @@ describe('Amperize', function () {
       });
     });
 
+    it('transforms <audio> with a fallback to <amp-audio>', function (done) {
+      amperize.parse('<audio src="http://foo.mp3" autoplay>Your browser does not support the <code>audio</code> element.</audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio');
+        expect(result).to.contain('src="https://foo.mp3"');
+        expect(result).to.contain('Your browser does not support the <code>audio</code> element.');
+        expect(result).to.contain('</amp-audio>');
+        done();
+      });
+    });
+
+    it('transforms <audio> with a <source> tag to <amp-audio> and maintains the attributes', function (done) {
+      amperize.parse('<audio controls="controls" width="auto" height="50" autoplay="mobile">Your browser does not support the <code>audio</code> element.<source src="http://foo.wav" type="audio/wav"></audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio');
+        expect(result).to.contain('controls="controls" width="auto" height="50" autoplay="mobile"');
+        expect(result).to.contain('<source src="https://foo.wav" type="audio/wav">');
+        expect(result).to.contain('</amp-audio>');
+        done();
+      });
+    });
+
+    it('transforms <audio> with a <track> tag to <amp-audio>', function (done) {
+      amperize.parse('<audio src="foo.ogg"><track kind="captions" src="https://foo.en.vtt" srclang="en" label="English"><track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska"></audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio src="foo.ogg">');
+        expect(result).to.contain('<track kind="captions" src="https://foo.en.vtt" srclang="en" label="English">');
+        expect(result).to.contain('<track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska">');
+        expect(result).to.contain('</amp-audio>');
+        done();
+      });
+    });
+
     it('can handle request errors by falling back to the default values defined in config', function (done) {
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')


### PR DESCRIPTION
no issue

needs #64 

- Transforms `<audio>` tags into `<amp-audio>`. Nested tags like `<source>` or `<track>` are not changed. Provided attributes stay the same.
- Transforms `http` schema to `https` for all `src` attributes (only for absolute URLs), as this is required for AMP.