### PR TITLE
✨ Add support for <audio>

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -162,7 +162,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
     }
 
     if ((element.name === 'img' || element.name === 'iframe') && !element.attribs.src) {
-      return enter('no src for ' + element.name + ' tag');
+      return enter();
     }
 
     if (element.name === 'img' && amperize.config.img) {
@@ -184,7 +184,20 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       element.name = 'amp-iframe';
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
-        // <amp-iframe> must be with 'https' protocol otherwise it will not get validated by AMP.
+
+        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
+        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
+        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
+        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
+      }
+    }
+
+    if (element.name === 'audio') {
+        element.name = 'amp-audio';
+    }
+
+    if (element.attribs && element.attribs.src) {
+        // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
         // If we're unable to replace it, we will deal with the valitation error, but at least
         // we tried.
         if (element.attribs.src.indexOf('https://') === -1) {
@@ -197,12 +210,6 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
                 element.attribs.src = 'https:' + element.attribs.src;
             }
         }
-
-        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
-        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
-        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
-        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
-      }
     }
 
     return enter();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,8 @@ var node = [
 
 var singular = [
   'area', 'base', 'br', 'col', 'command', 'embed', 'hr',
-  'img', 'input', 'link', 'meta', 'param', 'source', 'wbr'
+  'img', 'input', 'link', 'meta', 'param', 'source', 'wbr',
+  'track'
 ];
 
 function attributes(element) {

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -187,16 +187,50 @@ describe('Amperize', function () {
       });
     });
 
-    it('can handle <img> tag without src', function (done) {
-      amperize.parse('<img>', function (error, result) {
-        expect(result).to.not.exist;
+    it('can handle <img> tag without src and does not transform it', function (done) {
+      amperize.parse('<img><//img><p>some text here</p>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.be.equal('<img><p>some text here</p>');
         done();
       });
     });
 
-    it('can handle <iframe> tag without src', function (done) {
+    it('can handle <iframe> tag without src and does not transform it', function (done) {
       amperize.parse('<iframe>', function (error, result) {
-        expect(result).to.not.exist;
+        expect(result).to.exist;
+        expect(result).to.be.equal('<iframe></iframe>');
+        done();
+      });
+    });
+
+    it('transforms <audio> with a fallback to <amp-audio>', function (done) {
+      amperize.parse('<audio src="http://foo.mp3" autoplay>Your browser does not support the <code>audio</code> element.</audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio src="https://foo.mp3" autoplay="">');
+        expect(result).to.contain('Your browser does not support the <code>audio</code> element.');
+        expect(result).to.contain('</amp-audio>');
+        done();
+      });
+    });
+
+    it('transforms <audio> with a <source> tag to <amp-audio> and maintains the attributes', function (done) {
+      amperize.parse('<audio controls="controls" width="auto" height="50" autoplay="mobile">Your browser does not support the <code>audio</code> element.<source src="//foo.wav" type="audio/wav"></audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio');
+        expect(result).to.contain('controls="controls" width="auto" height="50" autoplay="mobile"');
+        expect(result).to.contain('<source src="https://foo.wav" type="audio/wav">');
+        expect(result).to.contain('</amp-audio>');
+        done();
+      });
+    });
+
+    it('transforms <audio> with a <track> tag to <amp-audio>', function (done) {
+      amperize.parse('<audio src="foo.ogg"><track kind="captions" src="https://foo.en.vtt" srclang="en" label="English"><track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska"></audio>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-audio src="foo.ogg">');
+        expect(result).to.contain('<track kind="captions" src="https://foo.en.vtt" srclang="en" label="English">');
+        expect(result).to.contain('<track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska">');
+        expect(result).to.contain('</amp-audio>');
         done();
       });
     });


### PR DESCRIPTION
Let's try this again 😉  Guess, it's easier this way...

no issue

- Transforms `<audio>` tags into `<amp-audio>`. Nested tags like `<source>` or `<track>` are not changed. Provided attributes stay the same.
- Transforms `http` schema to `https` for all `src` attributes (only for absolute URLs), as this is required for AMP.