### PR TITLE
🎨  Use layout="fixed" for small media types

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -14,12 +14,17 @@ var merge = require('lodash.merge')
   , helpers = require('./helpers');
 
 var DEFAULTS = {
-  img: {
+  'amp-img': {
     layout: 'responsive',
     width: 600,
     height: 400,
   },
-  iframe: {
+  'amp-anim': {
+    layout: 'responsive',
+    width: 600,
+    height: 400,
+  },
+  'amp-iframe': {
     layout: 'responsive',
     width: 600,
     height: 400,
@@ -121,6 +126,39 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       });
     }
 
+    function useSecureSchema(element) {
+        if (element.attribs && element.attribs.src) {
+            // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
+            // If we're unable to replace it, we will deal with the valitation error, but at least
+            // we tried.
+            if (element.attribs.src.indexOf('https://') === -1) {
+                if (element.attribs.src.indexOf('http://') === 0) {
+                    // Replace 'http' with 'https', so the validation passes
+                    element.attribs.src = element.attribs.src.replace(/^http:\/\//i, 'https://');
+                } else if (element.attribs.src.indexOf('//') === 0) {
+                    // Giphy embedded iFrames are without protocol and start with '//', so at least
+                    // we can fix those cases.
+                    element.attribs.src = 'https:' + element.attribs.src;
+                }
+            }
+        }
+
+      return;
+    }
+
+    function getLayoutAttribute(element) {
+      var layout;
+
+      // check if element.width is smaller than 300 px. In that case, we shouldn't use
+      // layout="responsive", because the media element will be stretched and it doesn't
+      // look nice. Use layout="fixed" instead to fix that.
+      layout = element.attribs.width < 300 ? layout = 'fixed' : amperize.config[element.name].layout;
+
+      element.attribs.layout = !element.attribs.layout ? layout : element.attribs.layout;
+
+      return enter();
+    }
+
     /**
      * Get the image sizes (width and heigth plus type of image)
      *
@@ -145,19 +183,22 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
                 var dimensions = sizeOf(Buffer.concat(chunks));
                 element.attribs.width = dimensions.width;
                 element.attribs.height = dimensions.height;
-                return enter();
+
+                return getLayoutAttribute(element);
             } catch (err) {
                 // fallback to default values, so the HTML get validated at least
-                element.attribs.width = amperize.config.img.width;
-                element.attribs.height = amperize.config.img.height;
-                return enter();
+                element.attribs.width = amperize.config['amp-img'].width;
+                element.attribs.height = amperize.config['amp-img'].height;
+
+                return getLayoutAttribute(element);
             }
         });
       }).on('error', function () {
         // fallback to default values, so the HTML get validated at least
-        element.attribs.width = amperize.config.img.width;
-        element.attribs.height = amperize.config.img.height;
-        return enter();
+        element.attribs.width = amperize.config['amp-img'].width;
+        element.attribs.height = amperize.config['amp-img'].height;
+
+        return getLayoutAttribute(element);
       });
     }
 
@@ -165,19 +206,19 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
       return enter();
     }
 
-    if (element.name === 'img' && amperize.config.img) {
+    if (element.name === 'img' && amperize.config['amp-img']) {
       // when we have a gif it should be <amp-anim>.
       element.name = element.attribs.src.match(/(\.gif$)/) ? 'amp-anim' : 'amp-img';
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
-        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
         if (element.attribs.src.indexOf('http') === 0) {
             return getImageSize(element);
-        } else {
-            element.attribs.width = amperize.config.img.width;
-            element.attribs.height = amperize.config.img.height;
         }
       }
+      // Fallback to default values for a local image
+      element.attribs.width = amperize.config['amp-img'].width;
+      element.attribs.height = amperize.config['amp-img'].height;
+      return getLayoutAttribute(element);
     }
 
     if (element.name ==='iframe') {
@@ -185,10 +226,13 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
 
-        element.attribs.layout = !element.attribs.layout ? amperize.config.iframe.layout : element.attribs.layout;
-        element.attribs.width = !element.attribs.width ? amperize.config.iframe.width : element.attribs.width;
-        element.attribs.height = !element.attribs.height ? amperize.config.iframe.height : element.attribs.height;
-        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config.iframe.sandbox : element.attribs.sandbox;
+        element.attribs.width = !element.attribs.width ? amperize.config['amp-iframe'].width : element.attribs.width;
+        element.attribs.height = !element.attribs.height ? amperize.config['amp-iframe'].height : element.attribs.height;
+        element.attribs.sandbox = !element.attribs.sandbox ? amperize.config['amp-iframe'].sandbox : element.attribs.sandbox;
+
+        useSecureSchema(element);
+
+        return getLayoutAttribute(element);
       }
     }
 
@@ -196,21 +240,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
         element.name = 'amp-audio';
     }
 
-    if (element.attribs && element.attribs.src) {
-        // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
-        // If we're unable to replace it, we will deal with the valitation error, but at least
-        // we tried.
-        if (element.attribs.src.indexOf('https://') === -1) {
-            if (element.attribs.src.indexOf('http://') === 0) {
-                // Replace 'http' with 'https', so the validation passes
-                element.attribs.src = element.attribs.src.replace(/^http:\/\//i, 'https://');
-            } else if (element.attribs.src.indexOf('//') === 0) {
-                // Giphy embedded iFrames are without protocol and start with '//', so at least
-                // we can fix those cases.
-                element.attribs.src = 'https:' + element.attribs.src;
-            }
-        }
-    }
+    useSecureSchema(element);
 
     return enter();
   }, done);

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -29,12 +29,17 @@ describe('Amperize', function () {
     it('which has default options', function () {
       expect(amperize).to.have.property('config');
       expect(amperize.config).to.be.eql({
-          img: {
+          'amp-img': {
             layout: 'responsive',
             width: 600,
             height: 400,
           },
-          iframe: {
+          'amp-anim': {
+            layout: 'responsive',
+            width: 600,
+            height: 400,
+          },
+          'amp-iframe': {
             layout: 'responsive',
             width: 600,
             height: 400,
@@ -86,7 +91,7 @@ describe('Amperize', function () {
       expect(err).throws('No callback provided');
     });
 
-    it('transforms <img> with layout property into <amp-img></amp-img> without overriding it and full image dimensions', function (done) {
+    it('transforms small <img> into <amp-img></amp-img> with full image dimensions and fixed layout', function (done) {
       sizeOfMock = nock('http://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
             .reply(200, {
@@ -96,13 +101,35 @@ describe('Amperize', function () {
       sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
       Amperize.__set__('sizeOf', sizeOfStub);
 
-      amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256" layout="FIXED">', function (error, result) {
+      amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256">', function (error, result) {
         expect(result).to.exist;
         expect(result).to.contain('<amp-img');
         expect(result).to.contain('src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256"');
-        expect(result).to.contain('layout="FIXED"');
+        expect(result).to.contain('layout="fixed"');
         expect(result).to.contain('width="50"');
         expect(result).to.contain('height="50"');
+        expect(result).to.contain('</amp-img>');
+        done();
+      });
+    });
+
+    it('transforms big <img> into <amp-img></amp-img> with full image dimensions and responsive layout', function (done) {
+      sizeOfMock = nock('http://static.wixstatic.com')
+            .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
+            .reply(200, {
+                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+      sizeOfStub.returns({width: 350, height: 200, type: 'jpg'});
+      Amperize.__set__('sizeOf', sizeOfStub);
+
+      amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256">', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-img');
+        expect(result).to.contain('src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="350"');
+        expect(result).to.contain('height="200"');
         expect(result).to.contain('</amp-img>');
         done();
       });


### PR DESCRIPTION
no issue

Using `layout="responsive"` as a default value might end in ugly results. Small images get stretched to fit in the parent container. Viewport for AMP should vary between 600px and 300px. In case, we have a media type smaller then 300px, we don't want to stretch it, so we set the fixed layout and AMP will use the detected media dimensions.