### PR TITLE
🐛  fix callback was already called

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -115,7 +115,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
 
     function enter(error) {
       if (error) {
-        return done(error);
+        return step(error);
       }
 
       children = element.children;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/7864

We experienced a bug that a callback get's called twice.
I went through the stack and found that a wrong callback is used in the `traverse` fn.
Everything get's wrapped into `async.reduce`. `reduce` will call `done` if the reduce logic finished.
`step` has to be used when a reduce step finished.