### PR TITLE
🐛  get image size error handling

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -193,10 +193,10 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
             } catch (err) {
                 if (called) return;
                 called = true;
-                var e = new Error();
-                e.message = err.message || err;
-                e.src = element.attribs.src
-                return enter(e);
+
+                // revert this element, do not show
+                element.name = 'img';
+                return enter();
             }
         });
       }).on('socket', function (socket) {
@@ -204,18 +204,18 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
         socket.on('timeout', function () {
             if (called) return;
             called = true;
-            var e = new Error();
-            e.message = 'Timeout while trying to fetch image sizes.';
-            e.src = element.attribs.src
-            return enter(e);
+
+            // revert this element, do not show
+            element.name = 'img';
+            return enter();
         });
-      }).on('error', function (error) {
+      }).on('error', function () {
         if (called) return;
         called = true;
-        var e = new Error();
-        e.message = error.message || error;
-        e.src = element.attribs.src
-        return enter(e);
+
+        // revert this element, do not show
+        element.name = 'img';
+        return enter();
       });
     }
 

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -282,9 +282,8 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
         expect(Amperize.__get__('called')).to.be.equal(true);
-        expect(error).to.exist;
-        expect(error.message).to.contain('something awful happened');
-        expect(result).to.not.exist;
+        expect(error).to.be.null;
+        expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();
       });
     });
@@ -300,9 +299,8 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
         expect(Amperize.__get__('called')).to.be.equal(true);
-        expect(error).to.exist;
-        expect(error.message.name).to.contain('error');
-        expect(result).to.not.exist;
+        expect(error).to.be.null;
+        expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();
       });
     });
@@ -317,9 +315,8 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
         expect(Amperize.__get__('called')).to.be.equal(true);
-        expect(error).to.exist;
-        expect(error.message).to.contain('Timeout while trying to fetch image sizes.');
-        expect(result).to.not.exist;
+        expect(error).to.be.null;
+        expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();
       });
     });


### PR DESCRIPTION
closes #95

- do not render no images if one image times out or is not found
- simply ignore this image

@jbhannah I am not 100% sure about the fix. Is it okay to revert the affected element back to an "img" element. I have tested this solution and it works good. The affected image get's ignored.