### PR TITLE
✨  Replace http and https with got

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var merge = require('lodash.merge')
-  , EventEmitter = require('events').EventEmitter
+var EventEmitter = require('events').EventEmitter
   , emits = require('emits')
   , html = require('htmlparser2')
   , util = require('util')
   , uuid = require('uuid')
   , async = require('async')
   , url = require('url')
-  , http = require('http')
-  , https = require('https')
+  , got = require('got')
+  , _ = require('lodash')
   , sizeOf = require('image-size')
+  , validator = require('validator')
   , helpers = require('./helpers');
 
 var DEFAULTS = {
@@ -32,8 +32,6 @@ var DEFAULTS = {
   }
 };
 
-var called;
-
 /**
  * Amperizer constructor. Borrows from Minimize.
  *
@@ -44,7 +42,7 @@ var called;
  * @api public
  */
 function Amperize(options) {
-  this.config = merge({}, DEFAULTS, options || {});
+  this.config = _.merge({}, DEFAULTS, options || {});
   this.emits = emits;
 
   this.htmlParser = new html.Parser(
@@ -129,21 +127,21 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
     }
 
     function useSecureSchema(element) {
-        if (element.attribs && element.attribs.src) {
-            // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
-            // If we're unable to replace it, we will deal with the valitation error, but at least
-            // we tried.
-            if (element.attribs.src.indexOf('https://') === -1) {
-                if (element.attribs.src.indexOf('http://') === 0) {
-                    // Replace 'http' with 'https', so the validation passes
-                    element.attribs.src = element.attribs.src.replace(/^http:\/\//i, 'https://');
-                } else if (element.attribs.src.indexOf('//') === 0) {
-                    // Giphy embedded iFrames are without protocol and start with '//', so at least
-                    // we can fix those cases.
-                    element.attribs.src = 'https:' + element.attribs.src;
-                }
-            }
+      if (element.attribs && element.attribs.src) {
+        // Every src attribute must be with 'https' protocol otherwise it will not get validated by AMP.
+        // If we're unable to replace it, we will deal with the valitation error, but at least
+        // we tried.
+        if (element.attribs.src.indexOf('https://') === -1) {
+          if (element.attribs.src.indexOf('http://') === 0) {
+            // Replace 'http' with 'https', so the validation passes
+            element.attribs.src = element.attribs.src.replace(/^http:\/\//i, 'https://');
+          } else if (element.attribs.src.indexOf('//') === 0) {
+            // Giphy embedded iFrames are without protocol and start with '//', so at least
+            // we can fix those cases.
+            element.attribs.src = 'https:' + element.attribs.src;
+          }
         }
+      }
 
       return;
     }
@@ -170,49 +168,52 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
      * @return {Object} element incl. width and height
      */
     function getImageSize(element) {
-      var options = url.parse(element.attribs.src),
-          timeout = 5000,
-          request = element.attribs.src.indexOf('https') === 0 ? https : http;
+      var imageObj = url.parse(element.attribs.src),
+          requestOptions,
+          timeout = 3000;
 
-      called = false;
+      if (!validator.isURL(imageObj.href)) {
+        // revert this element, do not show
+        element.name = 'img';
+
+        return enter();
+      }
 
       // We need the user-agent, otherwise some https request may fail (e. g. cloudfare)
-      options.headers = { 'User-Agent': 'Mozilla/5.0' };
+      requestOptions = {
+        headers: {
+            'User-Agent': 'Mozilla/5.0'
+        },
+        timeout: timeout,
+        encoding: null
+      };
 
-      return request.get(options, function (response) {
-        var chunks = [];
-        response.on('data', function (chunk) {
-          chunks.push(chunk);
-        }).on('end', function () {
-            try {
-                var dimensions = sizeOf(Buffer.concat(chunks));
-                element.attribs.width = dimensions.width;
-                element.attribs.height = dimensions.height;
+      return got (
+        imageObj.href,
+        requestOptions
+      ).then(function (response) {
+        try {
+          // Using the Buffer rather than an URL requires to use sizeOf synchronously.
+          // See https://github.com/image-size/image-size#asynchronous
+          var dimensions = sizeOf(response.body);
 
-                return getLayoutAttribute(element);
-            } catch (err) {
-                if (called) return;
-                called = true;
+          // CASE: `.ico` files might have multiple images and therefore multiple sizes.
+          // We return the largest size found (image-size default is the first size found)
+          if (dimensions.images) {
+            dimensions.width = _.maxBy(dimensions.images, function (w) {return w.width;}).width;
+            dimensions.height = _.maxBy(dimensions.images, function (h) {return h.height;}).height;
+          }
 
-                // revert this element, do not show
-                element.name = 'img';
-                return enter();
-            }
-        });
-      }).on('socket', function (socket) {
-        socket.setTimeout(timeout);
-        socket.on('timeout', function () {
-            if (called) return;
-            called = true;
+          element.attribs.width = dimensions.width;
+          element.attribs.height = dimensions.height;
 
-            // revert this element, do not show
-            element.name = 'img';
-            return enter();
-        });
-      }).on('error', function () {
-        if (called) return;
-        called = true;
-
+          return getLayoutAttribute(element);
+        } catch (err) {
+          // revert this element, do not show
+          element.name = 'img';
+          return enter();
+        }
+      }).catch(function (err) {
         // revert this element, do not show
         element.name = 'img';
         return enter();
@@ -229,7 +230,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
 
       if (!element.attribs.width || !element.attribs.height || !element.attribs.layout) {
         if (element.attribs.src.indexOf('http') === 0) {
-            return getImageSize(element);
+          return getImageSize(element);
         }
       }
       // Fallback to default values for a local image
@@ -254,7 +255,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
     }
 
     if (element.name === 'audio') {
-        element.name = 'amp-audio';
+      element.name = 'amp-audio';
     }
 
     useSecureSchema(element);

--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -103,19 +103,11 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
     var children;
 
     function close(error, html) {
-      if (error) {
-        return step(error);
-      }
-
       html += helpers.close(element);
       step(null, html);
     }
 
     function enter(error) {
-      if (error) {
-        return step(error);
-      }
-
       children = element.children;
       html += helpers[element.type](element);
 

--- a/package.json
+++ b/package.json
@@ -25,23 +25,25 @@
   },
   "homepage": "https://github.com/jbhannah/amperize#readme",
   "dependencies": {
-    "async": "2.1.4",
-    "emits": "3.0.0",
-    "htmlparser2": "3.9.2",
+    "async": "^2.1.4",
+    "emits": "^3.0.0",
+    "got": "^7.1.0",
+    "htmlparser2": "^3.9.2",
     "image-size": "0.5.1",
-    "lodash.merge": "4.6.0",
+    "lodash": "^4.17.4",
     "nock": "^9.0.2",
     "rewire": "^2.5.2",
-    "uuid": "^3.0.0"
+    "uuid": "^3.0.0",
+    "validator": "^8.2.0"
   },
   "devDependencies": {
-    "chai": "3.5.0",
+    "chai": "^3.5.0",
     "cz-conventional-changelog": "1.2.0",
-    "istanbul": "0.4.5",
-    "mocha": "3.2.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
     "semantic-release": "6.3.2",
-    "sinon": "1.17.7",
-    "sinon-chai": "2.8.0"
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   },
   "config": {
     "commitizen": {

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -95,7 +95,7 @@ describe('Amperize', function () {
       sizeOfMock = nock('http://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
       sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
@@ -103,7 +103,6 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256">', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-img');
         expect(result).to.contain('src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256"');
         expect(result).to.contain('layout="fixed"');
@@ -118,7 +117,7 @@ describe('Amperize', function () {
       sizeOfMock = nock('http://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
       sizeOfStub.returns({width: 350, height: 200, type: 'jpg'});
@@ -126,7 +125,6 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256">', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-img');
         expect(result).to.contain('src="http://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256"');
         expect(result).to.contain('layout="responsive"');
@@ -137,11 +135,87 @@ describe('Amperize', function () {
       });
     });
 
+    it('transforms <img> into <amp-img></amp-img> when width and height is set and overwrites it', function (done) {
+      sizeOfMock = nock('http://somestockwebsite.com')
+            .get('/image.jpg')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+      sizeOfStub.returns({width: 350, height: 200, type: 'jpg'});
+      Amperize.__set__('sizeOf', sizeOfStub);
+
+      amperize.parse('<img src="http://somestockwebsite.com/image.jpg" width="100" height="50">', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-img');
+        expect(result).to.contain('src="http://somestockwebsite.com/image.jpg"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="350"');
+        expect(result).to.contain('height="200"');
+        expect(result).to.contain('</amp-img>');
+        done();
+      });
+    });
+
+    it('transforms <img> into <amp-img></amp-img> does not overwrite layout attribute', function (done) {
+      sizeOfMock = nock('http://somestockwebsite.com')
+            .get('/image.jpg')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+      sizeOfStub.returns({width: 350, height: 200, type: 'jpg'});
+      Amperize.__set__('sizeOf', sizeOfStub);
+
+      amperize.parse('<img src="http://somestockwebsite.com/image.jpg" layout="fixed">', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-img');
+        expect(result).to.contain('src="http://somestockwebsite.com/image.jpg"');
+        expect(result).to.contain('layout="fixed"');
+        expect(result).to.contain('width="350"');
+        expect(result).to.contain('height="200"');
+        expect(result).to.contain('</amp-img>');
+        done();
+      });
+    });
+
+    it('returns largest image value for .ico files', function (done) {
+        sizeOfMock = nock('https://somewebsite.com')
+              .get('/favicon.ico')
+              .reply(200, {
+                  body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+              });
+
+        sizeOfStub.returns({
+            width: 32,
+            height: 32,
+            type: 'ico',
+            images: [
+              {width: 48, height: 48},
+              {width: 32, height: 32},
+              {width: 16, height: 16}
+            ]
+          });
+        Amperize.__set__('sizeOf', sizeOfStub);
+
+        amperize.parse('<img src="https://somewebsite.com/favicon.ico">', function (error, result) {
+          expect(result).to.exist;
+          expect(result).to.contain('<amp-img');
+          expect(result).to.contain('src="https://somewebsite.com/favicon.ico"');
+          expect(result).to.contain('layout="fixed"');
+          expect(result).to.contain('width="48"');
+          expect(result).to.contain('height="48"');
+          expect(result).to.contain('</amp-img>');
+          done();
+        });
+    });
+
+
     it('transforms .gif <img> with only height property into <amp-anim></amp-anim> with full dimensions by overriding them', function (done) {
       sizeOfMock = nock('https://media.giphy.com')
             .get('/media/l46CtzgjhTm29Cbjq/giphy.gif')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
       sizeOfStub.returns({width: 800, height: 600, type: 'gif'});
@@ -149,7 +223,6 @@ describe('Amperize', function () {
 
       amperize.parse('<img src="https://media.giphy.com/media/l46CtzgjhTm29Cbjq/giphy.gif" height="500">', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-anim');
         expect(result).to.contain('src="https://media.giphy.com/media/l46CtzgjhTm29Cbjq/giphy.gif"');
         expect(result).to.contain('layout="responsive"');
@@ -160,10 +233,9 @@ describe('Amperize', function () {
       });
     });
 
-    it('transforms <iframe> with only width property into <amp-iframe></amp-iframe> with full dimensions withour overriding them', function (done) {
+    it('transforms <iframe> with only width property into <amp-iframe></amp-iframe> with full dimensions without overriding them', function (done) {
       amperize.parse('<iframe src="https://www.youtube.com/embed/HMQkV5cTuoY" width="400"></iframe>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-iframe');
         expect(result).to.contain('src="https://www.youtube.com/embed/HMQkV5cTuoY"');
         expect(result).to.contain('layout="responsive"');
@@ -175,11 +247,38 @@ describe('Amperize', function () {
       });
     });
 
+    it('transforms <iframe> with only height property into <amp-iframe></amp-iframe> with full dimensions without overriding them', function (done) {
+      amperize.parse('<iframe src="https://www.youtube.com/embed/HMQkV5cTuoY" height="400"></iframe>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-iframe');
+        expect(result).to.contain('src="https://www.youtube.com/embed/HMQkV5cTuoY"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="600"');
+        expect(result).to.contain('height="400"');
+        expect(result).to.contain('</amp-iframe>');
+        expect(result).to.contain('sandbox="allow-scripts allow-same-origin"')
+        done();
+      });
+    });
+
+    it('transforms <iframe> with sandbox property into <amp-iframe></amp-iframe> with full dimensions without overriding them', function (done) {
+      amperize.parse('<iframe src="https://www.youtube.com/embed/HMQkV5cTuoY" sandbox="allow-scripts"></iframe>', function (error, result) {
+        expect(result).to.exist;
+        expect(result).to.contain('<amp-iframe');
+        expect(result).to.contain('src="https://www.youtube.com/embed/HMQkV5cTuoY"');
+        expect(result).to.contain('layout="responsive"');
+        expect(result).to.contain('width="600"');
+        expect(result).to.contain('height="400"');
+        expect(result).to.contain('</amp-iframe>');
+        expect(result).to.contain('sandbox="allow-scripts"')
+        done();
+      });
+    });
+
     it('adds \'https\' protocol to <iframe> if no protocol is supplied (e. e. giphy)', function (done) {
       var url = '<iframe src="//giphy.com/embed/3oEduKP4VaUxJvLwuA" width="480" height="372" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>';
       amperize.parse(url, function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-iframe');
         expect(result).to.contain('src="https://giphy.com/embed/3oEduKP4VaUxJvLwuA"');
         expect(result).to.contain('layout="responsive"');
@@ -195,7 +294,6 @@ describe('Amperize', function () {
       var url = '<iframe src="http://giphy.com/embed/3oEduKP4VaUxJvLwuA" width="480" height="372" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="http://giphy.com/gifs/afv-funny-fail-lol-3oEduKP4VaUxJvLwuA">via GIPHY</a></p></p>';
       amperize.parse(url, function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-iframe');
         expect(result).to.contain('src="https://giphy.com/embed/3oEduKP4VaUxJvLwuA"');
         expect(result).to.contain('layout="responsive"');
@@ -210,7 +308,6 @@ describe('Amperize', function () {
     it('transforms local <img> into <amp-img></amp-img> with default image dimensions', function (done) {
       amperize.parse('<img src="/content/images/IMG_xyz.jpg">', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-img');
         expect(result).to.contain('src="/content/images/IMG_xyz.jpg"');
         expect(result).to.contain('layout="responsive"');
@@ -224,16 +321,22 @@ describe('Amperize', function () {
     it('can handle <img> tag without src and does not transform it', function (done) {
       amperize.parse('<img><//img><p>some text here</p>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.be.equal('<img><p>some text here</p>');
         done();
+      });
+    });
+
+    it('can handle invalid URLs', function (done) {
+        amperize.parse('<img src="http:not-a-website">', function (error, result) {
+          expect(result).to.exist;
+          expect(result).to.be.equal('<img src="http:not-a-website">');
+          done();
       });
     });
 
     it('can handle <iframe> tag without src and does not transform it', function (done) {
       amperize.parse('<iframe>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.be.equal('<iframe></iframe>');
         done();
       });
@@ -242,7 +345,6 @@ describe('Amperize', function () {
     it('transforms <audio> with a fallback to <amp-audio>', function (done) {
       amperize.parse('<audio src="http://foo.mp3" autoplay>Your browser does not support the <code>audio</code> element.</audio>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-audio src="https://foo.mp3" autoplay="">');
         expect(result).to.contain('Your browser does not support the <code>audio</code> element.');
         expect(result).to.contain('</amp-audio>');
@@ -253,7 +355,6 @@ describe('Amperize', function () {
     it('transforms <audio> with a <source> tag to <amp-audio> and maintains the attributes', function (done) {
       amperize.parse('<audio controls="controls" width="auto" height="50" autoplay="mobile">Your browser does not support the <code>audio</code> element.<source src="//foo.wav" type="audio/wav"></audio>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-audio');
         expect(result).to.contain('controls="controls" width="auto" height="50" autoplay="mobile"');
         expect(result).to.contain('<source src="https://foo.wav" type="audio/wav">');
@@ -265,7 +366,6 @@ describe('Amperize', function () {
     it('transforms <audio> with a <track> tag to <amp-audio>', function (done) {
       amperize.parse('<audio src="foo.ogg"><track kind="captions" src="https://foo.en.vtt" srclang="en" label="English"><track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska"></audio>', function (error, result) {
         expect(result).to.exist;
-        expect(Amperize.__get__('called')).to.be.equal(false);
         expect(result).to.contain('<amp-audio src="foo.ogg">');
         expect(result).to.contain('<track kind="captions" src="https://foo.en.vtt" srclang="en" label="English">');
         expect(result).to.contain('<track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska">');
@@ -274,14 +374,43 @@ describe('Amperize', function () {
       });
     });
 
+    it('can handle redirects', function (done) {
+        var secondSizeOfMock;
+
+        sizeOfMock = nock('http://noimagehere.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(301, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            },
+            {
+                location: 'http://someredirectedurl.com/files/f/feedough/x/11/1540353_20925115.jpg'
+            });
+
+        secondSizeOfMock = nock('http://someredirectedurl.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+        sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
+        Amperize.__set__('sizeOf', sizeOfStub);
+
+
+        amperize.parse('<img src="http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg">', function (error, result) {
+          expect(sizeOfMock.isDone()).to.be.equal(true);
+          expect(secondSizeOfMock.isDone()).to.be.equal(true);
+          expect(error).to.be.null;
+          expect(result).to.contain('<amp-img src="http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg" width="100" height="100" layout="fixed"></amp-img>');
+          done();
+      });
+    });
+
     it('can handle request errors', function (done) {
-      var callCounts;
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')
-            .replyWithError('something awful happened');
+            .reply(404, {message: 'something awful happened', code: 'AWFUL_ERROR'});
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
-        expect(Amperize.__get__('called')).to.be.equal(true);
         expect(error).to.be.null;
         expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();
@@ -292,13 +421,12 @@ describe('Amperize', function () {
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
-      sizeOfStub.throws('error');
+      sizeOfStub.throws({error: 'image-size could not find dimensions'});
       Amperize.__set__('sizeOf', sizeOfStub);
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
-        expect(Amperize.__get__('called')).to.be.equal(true);
         expect(error).to.be.null;
         expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();
@@ -306,15 +434,16 @@ describe('Amperize', function () {
     });
 
     it('can handle timeout errors', function (done) {
+      this.timeout(3500);
+
       sizeOfMock = nock('http://example.com')
             .get('/images/IMG_xyz.jpg')
-            .socketDelay(5500)
+            .delay(3500)
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
       amperize.parse('<img src="http://example.com/images/IMG_xyz.jpg">', function (error, result) {
-        expect(Amperize.__get__('called')).to.be.equal(true);
         expect(error).to.be.null;
         expect(result).to.contain('<img src="http://example.com/images/IMG_xyz.jpg');
         done();


### PR DESCRIPTION
closes #99

- Used [`got`](https://github.com/sindresorhus/got) for image-size requests, which is more lightweight and has the huge advantage of following redirects
- Added and updated test
- indents
- Added dependencies:
    - [validator](https://github.com/chriso/validator.js)
    - [lodash](https://github.com/lodash/lodash)
    - [got](https://github.com/sindresorhus/got)