### PR TITLE
Added test for images w/o extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ var Amperize = require('amperize');
 
 var html = '<img src="https://example.com/image.jpg" />';
 
-amperize = new Amperize();
+var amperize = new Amperize();
 
 amperize.parse(html, function (error, result) {
     if (error) {
-            // do something with error
-            return new Error(err);
-        }
+        // do something with error
+        return new Error(err);
     }
     // do something with result
     return result;

--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -181,7 +181,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
             // We need the user-agent, otherwise some https request may fail (e. g. cloudfare)
             requestOptions = {
                 headers: {
-                    'User-Agent': 'Mozilla/5.0'
+                    'User-Agent': 'Mozilla/5.0 Safari/537.36'
                 },
                 timeout: timeout,
                 encoding: null

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -177,6 +177,31 @@ describe('Amperize', function () {
             });
         });
 
+        it('transforms <img> into <amp-img> when no file extension is given', function (done) {
+            // This test is mocked, but works with this specific example.
+            // You can comment out the mocks and the test should still pass.
+            sizeOfMock = nock('https://www.zomato.com')
+                .matchHeader('User-Agent', /Mozilla\/.*Safari\/.*/)
+                .get('/logo/18163505/minilogo')
+                .reply(200, {
+                    body: '<Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 68 00 00 00 0f 08 02 00 00 00 87 8f 1d 14 00 00 03 33 49 44 41 54 58 c3 ed 97 6b 48 93 51 18>'
+                });
+
+            sizeOfStub.returns({width: 104, height: 15, type: 'png'});
+            Amperize.__set__('sizeOf', sizeOfStub);
+
+            amperize.parse('<img src="https://www.zomato.com/logo/18163505/minilogo">', function (error, result) {
+                expect(result).to.exist;
+                expect(result).to.contain('<amp-img');
+                expect(result).to.contain('src="https://www.zomato.com/logo/18163505/minilogo"');
+                expect(result).to.contain('layout="fixed"');
+                expect(result).to.contain('width="104"');
+                expect(result).to.contain('height="15"');
+                expect(result).to.contain('</amp-img>');
+                done();
+            });
+        });
+
         it('returns largest image value for .ico files', function (done) {
             sizeOfMock = nock('https://somewebsite.com')
                 .get('/favicon.ico')


### PR DESCRIPTION
closes #97

Images without extensions don't need to be manipulated, as we're now reading the bytes and pass those to the `image-size` lib.

This PR adds another `user-agent` to emulate multiple browser requests, as I stumbled over an example where the image without extension is protected otherwise.

Added a test, that works with above mentioned image, but is currently mocked. Nevertheless, the image worked as a PoC, that we're able to read the bytes of an image without its extension and still return a valid `amp-img` tag.

Updated the README, as there were some code typos in there 🙈.