### PR TITLE
encodeURI before the image request

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -188,7 +188,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
             };
 
             return got(
-                imageObj.href,
+                encodeURI(imageObj.href),
                 requestOptions
             ).then(function (response) {
                 try {


### PR DESCRIPTION
Amperize crashes when trying to get an image (to get it's width and height values) from an http request using the "got" library, if the image URI is not encoded and it has special characters.

For example, when trying to:

`amperize.parse('<img src="https://example.com/tÚnez.jpg">');`

So, before the image request, it is necessary to encode the URI