### PR TITLE
Update got to v9.6.0 (drops support for EOL node versions 4 and 6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ notifications:
 node_js:
   - "10"
   - '8'
-  - '6'
-  - '4'
 
 before_script:
   - npm prune

--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -184,6 +184,7 @@ Amperize.prototype.traverse = function traverse(data, html, done) {
                     'User-Agent': 'Mozilla/5.0 Safari/537.36'
                 },
                 timeout: timeout,
+                retry: 0,
                 encoding: null
             };
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "semantic-release": "semantic-release"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8.6"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "emits": "^3.0.0",
-    "got": "^7.1.0",
+    "got": "^9.6.0",
     "htmlparser2": "^3.9.2",
     "image-size": "0.6.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
closes https://github.com/jbhannah/amperize/issues/119

- bump `got` to the latest version which properly handles URL encoding
- drops support for Node.js 4.x and 6.x which are now EOL (this is inline with latest `got` Node.js support)
  - update Travis config to remove testing on v4/v6