### PR TITLE
v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amperize",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "description": "AMP up your plain HTML",
   "main": "./lib/amperize",
   "scripts": {


### PR DESCRIPTION
no issue

Changelog:
- bump `got` version to fix issues with image URLs containing unescaped chars
- drop support for EOL Node.js 4.x and 6.x