### PR TITLE
🐛 Fixed conversion of `src` attribute in <source> tags to https

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -295,7 +295,7 @@ Amperize.prototype.traverse = async function traverse(data, html, done) {
             useSecureSchema(element);
         }
 
-        if (element.name === 'source' && element.parent.name === 'amp-audio') {
+        if (element.attribs && element.attribs.src && element.parent && element.parent.name === 'amp-audio') {
             useSecureSchema(element);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amperize",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AMP up your plain HTML",
   "main": "./lib/amperize",
   "scripts": {

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -439,6 +439,18 @@ describe('Amperize', function () {
             });
         });
 
+        it('transforms all src urls in <amp-audio> to https', function (done) {
+            amperize.parse('<audio src="//foo.ogg"><source type="audio/mpeg" src="http://foo.mp3"><track kind="captions" src="http://foo.en.vtt" srclang="en" label="English"><track kind="captions" src="http://foo.sv.vtt" srclang="sv" label="Svenska"></audio>', function (error, result) {
+                expect(result).to.exist;
+                expect(result).to.contain('<amp-audio src="https://foo.ogg">');
+                expect(result).to.contain('<source type="audio/mpeg" src="https://foo.mp3">');
+                expect(result).to.contain('<track kind="captions" src="https://foo.en.vtt" srclang="en" label="English">');
+                expect(result).to.contain('<track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska">');
+                expect(result).to.contain('</amp-audio>');
+                done();
+            });
+        })
+
         it('can handle redirects', function (done) {
             var secondImageSizeMock;
             var GIF1x1 = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==', 'base64');


### PR DESCRIPTION
no issue

- bug was introduced in 0.5.0
- adds regression test