### PR TITLE
🐛 Fixed fallback to image-size when url contains uppercase ext or query param

### DIFF
--- a/lib/amperize.js
+++ b/lib/amperize.js
@@ -33,6 +33,11 @@ var EventEmitter = require('events').EventEmitter,
         }
     };
 
+// these are formats supported by image-size but not probe-image-size
+const FETCH_ONLY_FORMATS = [
+    'cur', 'icns', 'ico', 'dds'
+];
+
 /**
 * Amperizer constructor. Borrows from Minimize.
 *
@@ -176,10 +181,10 @@ Amperize.prototype.traverse = async function traverse(data, html, done) {
             return Promise.resolve(imageSizeCache[url]);
         }
 
-        var [, extension] = url.match(/(?:\.)([a-zA-Z]{3,4})$/) || [];
-
         // fetch full image for formats we can't probe 
-        if (['cur', 'icns', 'ico', 'dds'].includes(extension)) {
+        const extensionMatch = url.match(/(?:\.)([a-zA-Z]{3,4})(\?|$)/) || [];
+        const extension = (extensionMatch[1] || '').toLowerCase();
+        if (FETCH_ONLY_FORMATS.includes(extension)) {
             return _fetchImageSize(url);
         }
         

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amperize",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AMP up your plain HTML",
   "main": "./lib/amperize",
   "scripts": {

--- a/test/amperize.test.js
+++ b/test/amperize.test.js
@@ -225,6 +225,40 @@ describe('Amperize', function () {
             });
         });
 
+        it('falls back to image-size for unprobable images (uppercase extension)', function (done) {
+            imageSizeMock = nock('https://somewebsite.com')
+                .get('/favicon.ICO')
+                .replyWithFile(200, path.join(__dirname, 'fixtures/multi-size.ico'));
+
+            amperize.parse('<img src="https://somewebsite.com/favicon.ICO">', function (error, result) {
+                expect(result).to.exist;
+                expect(result).to.contain('<amp-img');
+                expect(result).to.contain('src="https://somewebsite.com/favicon.ICO"');
+                expect(result).to.contain('layout="fixed"');
+                expect(result).to.contain('width="256"');
+                expect(result).to.contain('height="256"');
+                expect(result).to.contain('</amp-img>');
+                done();
+            });
+        });
+
+        it('falls back to image-size for unprobable images (query param)', function (done) {
+            imageSizeMock = nock('https://somewebsite.com')
+                .get('/favicon.ICO?v=1')
+                .replyWithFile(200, path.join(__dirname, 'fixtures/multi-size.ico'));
+
+            amperize.parse('<img src="https://somewebsite.com/favicon.ICO?v=1">', function (error, result) {
+                expect(result).to.exist;
+                expect(result).to.contain('<amp-img');
+                expect(result).to.contain('src="https://somewebsite.com/favicon.ICO?v=1"');
+                expect(result).to.contain('layout="fixed"');
+                expect(result).to.contain('width="256"');
+                expect(result).to.contain('height="256"');
+                expect(result).to.contain('</amp-img>');
+                done();
+            });
+        });
+
         it('returns largest image value for .ico files', function (done) {
             imageSizeMock = nock('https://somewebsite.com')
                 .get('/favicon.ico')


### PR DESCRIPTION
no issue

- ensure we're downcasing the detected extension so that we can get a match against our "unprobable" formats
- adjust the extension matching regex to account for potential query parameters on the url